### PR TITLE
fixed panic with zero sec

### DIFF
--- a/main.go
+++ b/main.go
@@ -61,13 +61,13 @@ func main() {
 	}
 
 	s := d.Milliseconds()
-	w := int(s)
+	w := int(s / 100)
 	if w < 1 {
 		w = 1
 	}
 	uiprogress.Start()
 
-	bar := uiprogress.AddBar(w / 100)
+	bar := uiprogress.AddBar(w)
 	bar.Width = 68
 	bar.AppendCompleted()
 


### PR DESCRIPTION

```
% ./sleepy 0   
panic: runtime error: index out of range [0] with length 0

goroutine 6 [running]:
github.com/gosuri/uiprogress.(*Bar).Bytes(0xc000108000)
        /go/pkg/mod/github.com/gosuri/uiprogress@v0.0.1/bar.go:195 +0x458
github.com/gosuri/uiprogress.(*Bar).String(...)
        /go/pkg/mod/github.com/gosuri/uiprogress@v0.0.1/bar.go:214
github.com/gosuri/uiprogress.(*Progress).print(0xc000062300)
        /go/pkg/mod/github.com/gosuri/uiprogress@v0.0.1/progress.go:127 +0x96
github.com/gosuri/uiprogress.(*Progress).Listen(0xc000062300)
        /go/pkg/mod/github.com/gosuri/uiprogress@v0.0.1/progress.go:116 +0xbb
created by github.com/gosuri/uiprogress.(*Progress).Start
        /go/pkg/mod/github.com/gosuri/uiprogress@v0.0.1/progress.go:134 +0x56
```